### PR TITLE
Add test suite for prime_function

### DIFF
--- a/uniformization/my_package/forward_problem.py
+++ b/uniformization/my_package/forward_problem.py
@@ -54,10 +54,7 @@ plot_branch_pts=False, product_threshold=12, max_time=200):
 	omega = build_prime_function(delta, q, product_threshold)
 #	except Exception, exc: #stop if it takes too long.
 #		print exc
-	
-	# Test that the prime function obeys certain things we expect.
-	if prime_function_tests: test_prime_function(omega,delta,q)
-	
+
 	# Build the slitmap
 	slitmap = build_slitmap(omega)
 	

--- a/uniformization/my_package/prime_function.py
+++ b/uniformization/my_package/prime_function.py
@@ -47,7 +47,7 @@ def build_omegap(word_length):
 								# elements associated with different WORDS
 								# then return
 	return reduce(operator.mul, output, 1)
-	
+
 # This is the workhorse helper function
 def iterate_words(w):
 
@@ -59,94 +59,3 @@ def iterate_words(w):
 							# into products of the phi_j
 	return (phi_i - gamma)*(phi_i(z=gamma)-z)/( (phi_i - z)*(phi_i(z=gamma) -\
 				gamma) )
-	
-
-def test_prime_function(omega, delta, q):
-###############################################################################
-# Run various tests on the prime function to see that it is calculated well.
-# Right now we only have very basic tests. Add more complex ones later?
-#
-# requires: omega, delta, q
-##############################################################################
-	z = var('z')
-	gamma = var('gamma')
-	genus = len(q)
-	phi_j = [ delta[j] + q[j]**2*z/(1-z*delta[j].conjugate()) for j in
-				xrange(genus)]
-	
-
-	print '------------------Prime Function Tests ---------------------'
-	## First, we better have omega(gamma1,gamma2)=0
-	test = 'Failed'
-	if (simplify( omega(z=gamma) ) == 0): test='Passed' #Check!
-	print 'prime function test 1:			', test
-	
-	## We better also have omega vanishing at the image of gamma under phi_j
-	test = 'Failed'
-	if (sum( [simplify( omega(z=phi_j[k](z=gamma)) ) for k in range(genus)]\
-			)==0):
-		test='Passed'  #should=0
-	print 'prime function test 2:			', test
-	
-	## There should be a pole at the fixed points of phi_j. These are given
-	## analytically by
-	pole_pt1 = lambda k: (1+abs(delta[k])**2 - q[k]**2 + sqrt(-4*abs(delta[k])^2 +
-	(1+abs(delta[k])**2 - q[k]^2)^2))/(2*delta[k].conjugate())
-	pole_pt2 = lambda k: (1+abs(delta[k])**2 - q[k]**2 - sqrt(-4*abs(delta[k])^2 +
-	(1+abs(delta[k])**2 - q[k]**2)**2))/(2*delta[k].conjugate())
-	## First make sure that these are in fact fixed points of phi_j
-	test = 'Failed'
-	pole_sum1 = sum( [N( phi_j[k](z=pole_pt1(k)) - pole_pt1(k)) for k in \
-					range(genus)] )
-	pole_sum2 = sum( [N( phi_j[k](z=pole_pt2(k)) - pole_pt2(k)) for k in \
-					range(genus)] )
-	if abs( pole_sum1 + pole_sum2 ) < exp(-28): test='Passed'
-	print 'Pole points verified:			', test
-	
-	## If we just plug these in we should get an error. To check let's perturb a
-	## little and plug in a particular value of gamma!
-	test = 'Failed'
-	sum1 = sum( [N( omega(z = pole_pt1(k) + 1e-10, gamma = 1) + omega(z =
-	pole_pt2(k) + 1e-10, gamma = 1) ) for k in range(genus)] )
-	sum2 = sum( [N( omega(z = pole_pt1(k) + 1e-13, gamma = 1) + omega(z = 
-	pole_pt2(k) + 1e-13, gamma = 1) ) for k in range(genus)] )
-	sum3 = sum( [N( omega(z = pole_pt1(k) + 1e-15, gamma = 1) + omega(z = 
-	pole_pt2(k) + 1e-15, gamma = 1) ) for k in range(genus)] )
-	if ( (abs(sum3)>abs(sum2))&(abs(sum2)>abs(sum1)) ): test = 'Passed'
-	print 'test3:					', test
-	
-	### The above sequence should be increasing, check!
-	test = 'Failed'
-	sum1 = sum( [N( omega(z = pole_pt1(k) + 1e-10, gamma = 1) + omega(z = 
-	pole_pt2(k) + 1e-10, gamma = -1) ) for k in range(genus)] )
-	sum2 = sum( [N( omega(z = pole_pt1(k) + 1e-13, gamma = 1) + omega(z = 
-	pole_pt2(k) + 1e-13, gamma = -1) ) for k in range(genus)] )
-	sum3 = sum( [N( omega(z = pole_pt1(k) + 1e-15, gamma = 1) + omega(z = 
-	pole_pt2(k) + 1e-15, gamma = -1) ) for k in range(genus)] )
-	### This one too! check!
-	if ( (abs(sum3)>abs(sum2))&(abs(sum2)>abs(sum1)) ): test = 'Passed'
-	print 'test4:					', test
-	
-	# We also check to see if (5.17) holds, it doesn't unless we take the
-	# infinite
-	# product, but should approach it as the product_threshold increases! Again
-	# choose a number for gamma
-	fiveone7a = omega(z = 1/z.conjugate(), gamma = 1/gamma.conjugate())
-	fiveone7 = fiveone7a.conjugate() + omega/(z*gamma)
-	fiveone7test = abs(N(fiveone7(z=3+I*3,gamma=1)) )
-	print 'test5, (5.17) should be as small as possible:	', str(fiveone7test)
-	fiveone7testb = abs(N(fiveone7(z=0.7+0.1*I,gamma=1)) )
-	print 'test6, (5.17) should be as small as possible:	', \
-				str(fiveone7testb)
-	
-	
-	# The SK-prime function should also be symmetric in its arguments. I.e. one
-	# should have omega(zeta,gamma) = -omega(gamma,zeta). Test this
-	# algebraically
-	test = 'Failed'
-	pvar = var('pvar'); qvar = var('qvar')
-	if ( simplify(omega(z=pvar,gamma=qvar)+omega(z=qvar,gamma=pvar)) ) == 0:
-		test = 'Passed'
-	print 'test7:					', test
-	
-	print '---------------- End Prime Function Tests --------------------'

--- a/uniformization/my_package/tests/test_prime_function.py
+++ b/uniformization/my_package/tests/test_prime_function.py
@@ -1,0 +1,114 @@
+from sage.all import *
+from nose.plugins.skip import SkipTest
+
+from my_package.prime_function import build_prime_function
+
+
+
+#############################################################################
+# The following tests use the nosetest generator syntax. See                #
+#                                                                           #
+# https://nose.readthedocs.org/en/latest/writing_tests.html#test-generators #
+#                                                                           #
+# for more information. The "checks" used by these tests are defined below. #
+#############################################################################
+z = var('z')
+gamma = var('gamma')
+
+def test_prime_function():
+    # run the "checks" below using the following list of (delta,q) pairs
+    half = QQ(1)/2
+    delta_q_pairs = [
+        # ([0], [half]),
+        ([half], [half/4]),
+        ([-half, half], [half/2, half/2]),
+    ]
+    product_threshold = 10
+
+    for delta, q in delta_q_pairs:
+        genus = len(delta)
+        omega = build_prime_function(delta, q, product_threshold)
+        phi_j = [
+            delta[j] + q[j]**2*z/(1-z*delta[j].conjugate())
+            for j in range(genus)
+        ]
+        yield check_vanishing_gamma, omega
+        yield check_vanishing_phij_gamma, omega, phi_j
+        yield check_pole_fixed_points, omega, delta, q, phi_j, genus
+        # yield check_equation_5_17, omega
+        yield check_symmetric, omega
+
+##########
+# checks #
+##########
+def check_vanishing_gamma(omega):
+    # Tests that omega(gamma1,gamma2) vanishes.
+    value = omega(z=gamma)
+    assert simplify(value) == 0
+
+def check_vanishing_phij_gamma(omega, phi_j):
+    # Tests that omega(phi_j(gamma1), phi_j(gamma2)) vanishes.
+    value = sum(omega(z=phi_jk(z=gamma)) for phi_jk in phi_j)
+    assert simplify(value) == 0
+
+def check_pole_fixed_points(omega, delta, q, phi_j, genus):
+    # Tests that omega has poles at the fixed points of phi_j.
+    term_1 = lambda k: 1 + abs(delta[k])**2 - q[k]**2
+    term_2 = lambda k: sqrt(-4*abs(delta[k])**2 + (1+abs(delta[k])**2-q[k]**2)**2)
+    denom = lambda k: 2*delta[k].conjugate()
+    pole_pt1 = lambda k: (term_1(k) + term_2(k)) / denom(k)
+    pole_pt2 = lambda k: (term_1(k) - term_2(k)) / denom(k)
+
+    # assert that these are, in fact, fixed poitns of phi_j
+    pole_sum1 = sum(N(phi_j[k](z=pole_pt1(k)) - pole_pt1(k)) for k in range(genus))
+    pole_sum2 = sum(N(phi_j[k](z=pole_pt2(k)) - pole_pt2(k)) for k in range(genus))
+    value = pole_sum1 + pole_sum2
+    assert abs(simplify(value)) < 1e-15
+
+    # perturb slightly to avoid returning an error (result should be large?).
+    # as we get closer to the pole the values should be increasing (towards
+    # infinity)
+    sum1 = sum(N(omega(z=pole_pt1(k) + 1e-10, gamma=1) +
+                 omega(z=pole_pt2(k) + 1e-10, gamma=1))
+               for k in range(genus))
+    sum2 = sum(N(omega(z=pole_pt1(k) + 1e-13, gamma=1) +
+                 omega(z=pole_pt2(k) + 1e-13, gamma=1))
+               for k in range(genus))
+    sum3 = sum(N(omega(z=pole_pt1(k) + 1e-15, gamma=1) +
+                 omega(z=pole_pt2(k) + 1e-15, gamma=1))
+               for k in range(genus))
+    assert abs(sum3) > abs(sum2) > abs(sum1)
+
+    # repeat at gamma = -1
+    sum1 = sum(N(omega(z=pole_pt1(k) + 1e-10, gamma=1) +
+                 omega(z=pole_pt2(k) + 1e-10, gamma=-1))
+               for k in range(genus))
+    sum2 = sum(N(omega(z=pole_pt1(k) + 1e-13, gamma=1) +
+                 omega(z=pole_pt2(k) + 1e-13, gamma=-1))
+               for k in range(genus))
+    sum3 = sum(N(omega(z=pole_pt1(k) + 1e-15, gamma=1) +
+                 omega(z=pole_pt2(k) + 1e-15, gamma=-1))
+               for k in range(genus))
+    assert abs(sum3) > abs(sum2) > abs(sum1)
+
+def check_equation_5_17(omega):
+    # we also check to see if (5.17) holds, it doesn't unless we take the
+    # infinite product, but should approach it as the product_threshold
+    # increases! Again choose a number for gamma.
+    fiveone7a = omega(z=1/z.conjugate(), gamma=1/gamma.conjugate())
+    fiveone7 = fiveone7a.conjugate() + omega/(z*gamma)
+    value = abs(N(fiveone7(z=(3+I*3),gamma=1)))
+    assert simplify(value) < 1e-8
+
+    value = abs(N(fiveone7(z=0.7+0.1*I,gamma=1)) )
+    assert simplify(value) < 1e-8
+
+def check_symmetric(omega):
+    # the SK-prime function should also be symmetric in its arguments. I.e. one
+    # should have omega(zeta,gamma) = -omega(gamma,zeta). Test this
+    # algebraically
+    p = var('p')
+    q = var('q')
+    value = omega(z=p,gamma=q) + omega(z=q,gamma=p)
+    assert simplify(value) == 0
+

--- a/uniformization/runtests.py
+++ b/uniformization/runtests.py
@@ -1,0 +1,12 @@
+# run this using sage
+try:
+    import sage
+except ImportError:
+    raise ImportError('Run runtests.py with Sage:\tsage runtests.py')
+
+try:
+    import nose
+except ImportError:
+    raise ImportError('Install nose:\t$ sage -i nose')
+
+nose.main(module='my_package')


### PR DESCRIPTION
We separate out the prime_function module tests into a test suite which is run using nose. Specifically, the user runs the suite using

```
$ sage runtests.py
```

provided.

The purpose of this separation is to isolate where the testing examples occur as well as to make sure that the tests for prime_function run independently of the other code in the library. (e.g. forward_problem)

Other modules should be tested in this way.
